### PR TITLE
Make MaybeProjection/DefaultProjection work on non exists map key

### DIFF
--- a/src/claro/projection/maps.cljc
+++ b/src/claro/projection/maps.cljc
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [alias])
   (:require [claro.projection.protocols :as pr]
             [claro.projection.value :refer [value?]]
+            [claro.projection.maybe :refer [maybe? default?]]
             [claro.data.ops.chain :as chain]
             [claro.data.error :refer [with-error?]]))
 
@@ -60,7 +61,8 @@
 
 (defn- project-value
   [this unresolved-value value key template]
-  (assert-contains! this unresolved-value value key template)
+  (when-not (or (maybe? template) (default? template))
+    (assert-contains! this unresolved-value value key template))
   (pr/project template (get value key)))
 
 (defn- project-aliased-value

--- a/src/claro/projection/maybe.cljc
+++ b/src/claro/projection/maybe.cljc
@@ -21,6 +21,10 @@
   [template]
   (->MaybeProjection template))
 
+(defn ^:no-doc maybe?
+  [v]
+  (instance? MaybeProjection v))
+
 (defmethod print-method MaybeProjection
   [^MaybeProjection value ^java.io.Writer w]
   (.write w "#<claro/maybe ")
@@ -55,3 +59,7 @@
   (.write w " | ")
   (print-method (.-default-value value) w)
   (.write w ">"))
+
+(defn ^:no-doc default?
+  [v]
+  (instance? DefaultProjection v))


### PR DESCRIPTION
Projection template with non exists keys will fail with `IllegalArgumentException` even if use `projection/maybe`, it is expected behavior. But in my case, the datasource is a legacy system, the data model is not strictly shaped. So i have to normalize the data after fetching from the backend datasource, it is tedious.

I want it behavior like this:

```clojure
(engine (pj/apply {:user-id 123 :username "Claro"}
                  (pj/maybe {:user-id  pj/leaf
                             :username pj/leaf
                             :phone    (pj/maybe pj/leaf)})))
;; => {:user-id 123, :username "Claro", :phone nil}

(engine (pj/apply {:user-id 123 :username "Claro"}
                  (pj/maybe {:user-id  pj/leaf
                             :username pj/leaf
                             :phone    (pj/default pj/leaf "default-phone-number")})))
;; => {:user-id 123, :username "Claro", :phone "default-phone-number"}
```

I don't know whether it is make sense, or do you have other concern?

Thank you for making this great library.


