### PR TITLE
Default Value Injections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: clojure
-lein: lein2
 jdk:
   - oraclejdk8

--- a/src/claro/projection/maps.cljc
+++ b/src/claro/projection/maps.cljc
@@ -1,11 +1,36 @@
 (ns claro.projection.maps
   (:refer-clojure :exclude [alias])
   (:require [claro.projection.protocols :as pr]
-            [claro.projection.value :refer [value?]]
             [claro.data.ops.chain :as chain]
-            [claro.data.error :refer [with-error?]]))
+            [claro.data.error :refer [with-error?]]
+            [potemkin :refer [defprotocol+]]))
 
-;; ## Assertions
+;; ## Helpers
+
+(defn- throw-missing-key!
+  [value-projection k]
+  (throw
+    (IllegalArgumentException.
+      (format
+        (str "projection template expects key '%s' but value does not "
+             "contain it.%n"
+             "value template: %s")
+        (pr-str k)
+        (pr-str value-projection)))))
+
+(defn- rethrow-with-meta!
+  [^Throwable t projection unresolved-value value]
+  (throw
+    (IllegalArgumentException.
+      (format
+        (str "%s%n"
+             "resolvable:     %s%n"
+             "template:       %s%n"
+             "available keys: %s")
+        (.getMessage t)
+        (pr-str unresolved-value)
+        (pr-str projection)
+        (pr-str (vec (keys value)))))))
 
 (defn- assert-map!
   [unresolved-value value template]
@@ -22,57 +47,78 @@
           (pr-str value)))))
   value)
 
-(defn- assert-contains!
-  [this unresolved-value value k template]
-  (when-not (or (contains? value k)
-                (value? template))
-    (throw
-      (IllegalArgumentException.
-        (format
-          (str "projection template expects key '%s' but value does not "
-               "contain it.%n"
-               "resolvable:     %s%n"
-               "template:       %s%n"
-               "available keys: %s")
-          k
-          (pr-str unresolved-value)
-          (pr-str this)
-          (pr-str (vec (keys value)))))))
-  value)
-
 (defn- assert-no-override!
-  [this unresolved-value value k]
+  [alias-projection value k]
   (when (contains? value k)
     (throw
       (IllegalArgumentException.
-        (format
-          (str "'alias' projection " (pr-str this)
-               " would override key '" k "'.%n"
-               "resolvable: %s%n"
-               "template:   %s%n"
-               "value:      %s")
-          (pr-str unresolved-value)
-          (pr-str this)
-          (pr-str value)))))
-  value)
+        (format "'alias' projection '%s' would override key '%s'."
+                (pr-str alias-projection)
+                (pr-str k))))))
 
-;; ## Projection Logic
+;; ## Value Projections
+;;
+;; This can be used by `maybe` and `default` projections to provide
+;; default values, as well as by `value` to override existing values.
 
-(defn- project-value
-  [this unresolved-value value key template]
-  (assert-contains! this unresolved-value value key template)
-  (pr/project template (get value key)))
+(defprotocol+ MapValueProjection
+  "Protocol for projections used for map values."
+  (project-value
+    [value-projection value]
+    "Project the given map value.")
+  (project-missing-value
+    [value-projection k]
+    "Handle a missing map value at the given key."))
 
-(defn- project-aliased-value
-  [this unresolved-value value alias-key key template]
-  (assert-no-override! this unresolved-value value alias-key)
-  (project-value this unresolved-value value key template))
+(extend-protocol MapValueProjection
+  Object
+  (project-value [value-projection value]
+    (pr/project value-projection value))
+  (project-missing-value [value-projection k]
+    (throw-missing-key! value-projection k))
+
+  nil
+  (project-value [value-projection value]
+    (pr/project value-projection value))
+  (project-missing-value [value-projection k]
+    (throw-missing-key! value-projection k)))
+
+(defn- project-value-or-missing
+  [value-projection m k]
+  (let [value (get m k ::none)]
+    (if (= value ::none)
+      (project-missing-value value-projection k)
+      (project-value value-projection value))))
+
+;; ## Map Key Handling
+
+(defprotocol+ MapKeyProjection
+  "Protocol for map key projection semantics, e.g. aliasing."
+  (target-key [key-projection value])
+  (source-key [key-projection value]))
+
+(extend-protocol MapKeyProjection
+  Object
+  (target-key [this value] this)
+  (source-key [this value] this)
+
+  nil
+  (target-key [this value] this)
+  (source-key [this value] this))
+
+;; ## Assertions
 
 ;; ## Alias Keys
 ;;
 ;; This can be used directly in maps to indicate a renamed/copied key.
 
-(defrecord AliasKey [alias-key key])
+(defrecord AliasKey [alias-key key]
+  MapKeyProjection
+  (target-key [this value]
+    (assert-no-override! this value alias-key)
+    alias-key)
+  (source-key [_ value]
+    key))
 
 (defmethod print-method AliasKey
   [^AliasKey value ^java.io.Writer w]
@@ -111,30 +157,26 @@
   (with-error? value
     (assert-map! unresolved-value value this)
     (if-not (empty? this)
-      (let [project-unaliased
-            #(project-value this unresolved-value value %1 %2)
-            project-aliased
-            #(project-aliased-value this unresolved-value value %1 %2 %3)]
+      (try
         (loop [template (seq this)
                keys     (transient [])
                values   (transient [])]
           (if template
-            (let [[k value-template] (first template)]
-              (if (instance? AliasKey k)
-                (let [{:keys [key alias-key]} k
-                      value (project-aliased alias-key key value-template)]
-                  (recur
-                    (next template)
-                    (conj! keys alias-key)
-                    (conj! values value)))
-                (let [value (project-unaliased k value-template)]
-                  (recur
-                    (next template)
-                    (conj! keys k)
-                    (conj! values value)))))
+            (let [e (first template)
+                  key-projection (key e)
+                  value-projection (val e)
+                  tk (target-key key-projection value)
+                  sk (source-key key-projection value)
+                  v  (project-value-or-missing value-projection value sk)]
+              (recur
+                (next template)
+                (conj! keys tk)
+                (conj! values v)))
             (let [ks (persistent! keys)
                   vs (persistent! values)]
-              (chain/chain-blocking* vs #(zipmap ks %))))))
+              (chain/chain-blocking* vs #(zipmap ks %)))))
+        (catch Throwable t
+          (rethrow-with-meta! t this unresolved-value value)))
       {})))
 
 (extend-protocol pr/Projection

--- a/src/claro/projection/value.cljc
+++ b/src/claro/projection/value.cljc
@@ -1,7 +1,9 @@
 (ns claro.projection.value
   (:require [claro.projection.protocols :as pr]
             [claro.data.error :refer [with-error?]]
-            [claro.projection.objects :refer [leaf]]))
+            [claro.projection
+             [objects :refer [leaf]]
+             [maps :as maps]]))
 
 ;; ## Record
 
@@ -11,11 +13,15 @@
     (with-error? value'
       (if template
         (pr/project template value)
-        value))))
+        value)))
 
-(defn ^:no-doc value?
-  [v]
-  (instance? ValueProjection v))
+  maps/MapValueProjection
+  (project-value [this value]
+    (pr/project this value))
+  (project-missing-value [this _]
+    (if template
+      (pr/project template value)
+      value)))
 
 (defmethod print-method ValueProjection
   [^ValueProjection value ^java.io.Writer w]

--- a/test/claro/projection/maybe_test.clj
+++ b/test/claro/projection/maybe_test.clj
@@ -1,0 +1,62 @@
+(ns claro.projection.maybe-test
+  (:require [clojure.test.check
+             [clojure-test :refer [defspec]]
+             [generators :as gen]
+             [properties :as prop]]
+            [clojure.test :refer :all]
+            [claro.test :as test]
+            [claro.projection.generators :as g]
+            [claro.engine.fixtures :refer [make-engine]]
+            [claro.data.ops :as ops]
+            [claro.projection :as projection]))
+
+(defspec t-maybe (test/times 200)
+  (let [run! (make-engine)]
+    (prop/for-all
+      [template (g/valid-template)
+       value    (gen/one-of
+                  [(g/infinite-seq)
+                   (gen/return (g/->Identity nil))])]
+      (let [maybe-template  (projection/maybe template)
+            should-be-nil?  (contains? value :value)
+            projected-value (projection/apply value maybe-template)
+            result          @(run! projected-value)]
+        (if should-be-nil?
+          (nil? result)
+          (= result @(run! (projection/apply value template))))))))
+
+(defspec t-default (test/times 200)
+  (let [run! (make-engine)]
+    (prop/for-all
+      [template (g/valid-template)
+       value    (gen/one-of
+                  [(g/infinite-seq)
+                   (gen/return (g/->Identity nil))])
+       default-value (g/infinite-seq-no-mutation)]
+      (let [default-template (projection/default template default-value)
+            should-be-nil?   (contains? value :value)
+            projected-value  (projection/apply value default-template)
+            result           @(run! projected-value)]
+        (if should-be-nil?
+          (= result @(run! (projection/apply default-value template)))
+          (= result @(run! (projection/apply value template))))))))
+
+(deftest t-maybe-on-missing-key
+  (let [run! (make-engine)
+        value {:a 0}
+        template {:b (projection/maybe projection/leaf)}]
+    (is
+      (thrown-with-msg?
+        IllegalArgumentException
+        #"projection template expects key"
+        @(run! (projection/apply value template))))))
+
+(deftest t-default-on-missing-key
+  (let [run! (make-engine)
+        value {:a 0}
+        template {:b (projection/default projection/leaf 4)}]
+    (is
+      (thrown-with-msg?
+        IllegalArgumentException
+        #"projection template expects key"
+        @(run! (projection/apply value template))))))

--- a/test/claro/projection/maybe_test.clj
+++ b/test/claro/projection/maybe_test.clj
@@ -45,18 +45,12 @@
   (let [run! (make-engine)
         value {:a 0}
         template {:b (projection/maybe projection/leaf)}]
-    (is
-      (thrown-with-msg?
-        IllegalArgumentException
-        #"projection template expects key"
-        @(run! (projection/apply value template))))))
+    (is (= {:b nil}
+           @(run! (projection/apply value template))))))
 
 (deftest t-default-on-missing-key
   (let [run! (make-engine)
         value {:a 0}
         template {:b (projection/default projection/leaf 4)}]
-    (is
-      (thrown-with-msg?
-        IllegalArgumentException
-        #"projection template expects key"
-        @(run! (projection/apply value template))))))
+    (is (= {:b 4}
+           @(run! (projection/apply value template))))))

--- a/test/claro/projection/value_test.clj
+++ b/test/claro/projection/value_test.clj
@@ -1,0 +1,38 @@
+(ns claro.projection.value-test
+  (:require [clojure.test.check
+             [clojure-test :refer [defspec]]
+             [generators :as gen]
+             [properties :as prop]]
+            [clojure.test :refer :all]
+            [claro.test :as test]
+            [claro.projection.generators :as g]
+            [claro.engine.fixtures :refer [make-engine]]
+            [claro.projection :as projection]))
+
+(defspec t-value-injection (test/times 200)
+  (let [run! (make-engine)]
+    (prop/for-all
+      [template        (g/valid-template)
+       value           (g/infinite-seq)
+       value-to-inject gen/simple-type-printable]
+      (let [template-with-injection
+            (assoc template
+                   :extra-value
+                   (projection/value value-to-inject))
+            projected-value
+            (projection/apply value template)
+            projected-value-with-injection
+            (projection/apply value template-with-injection)]
+        (= @(run! projected-value-with-injection)
+           (-> @(run! projected-value)
+               (assoc :extra-value value-to-inject)))))))
+
+(defspec t-value-override (test/times 200)
+  (let [run! (make-engine)]
+    (prop/for-all
+      [value           (g/infinite-seq)
+       value-to-inject gen/simple-type-printable]
+      (let [template {:next (projection/value value-to-inject)}
+            projected-value (projection/apply value template)]
+        (= {:next value-to-inject}
+           @(run! projected-value))))))


### PR DESCRIPTION
See #13. This lets `maybe` and `default` inject values into maps instead of insisting on existence of the respective keys.

Note that this is technically a breaking change, albeit with minor implications since code that currently complies to a projection will still work.