### PR TITLE
Interception + Caching Middleware

### DIFF
--- a/src/claro/data/tree/utils.cljc
+++ b/src/claro/data/tree/utils.cljc
@@ -17,13 +17,3 @@
 (def all-resolvables-xf
   "Transducer to collect all resolvables in a seq of `ResolvableTree`values."
   (mapcat #(p/resolvables* %)))
-
-(def all-unwrap-xf
-  "Transducer to unwrap a collection of elements."
-  (map #(p/partial-value % ::this-should-not-happen)))
-
-(defn merge-resolvables
-  ([trees]
-   (into [] all-resolvables-xf trees))
-  ([tree0 tree1]
-   (into (p/resolvables* tree0) (p/resolvables* tree1))))

--- a/src/claro/engine/selector.cljc
+++ b/src/claro/engine/selector.cljc
@@ -5,11 +5,12 @@
    See the [Engine][1] documentation.
 
    [1]: 03-engine.md
-   ")
+   "
+  (:require [potemkin :refer [defprotocol+]]))
 
 ;; ## Protocol
 
-(defprotocol Selector
+(defprotocol+ Selector
   (instantiate [selector]
     "Generate a selector instance, i.e. a function taking a map of
      classes/resolvables and returning a seq of classes to resolve during

--- a/src/claro/middleware/cache.cljc
+++ b/src/claro/middleware/cache.cljc
@@ -24,13 +24,9 @@
 
 (defn- cache-writer
   [cache]
-  (fn [env batch resolvable->result]
-    (let [cacheable (->> (for [[resolvable result :as e] resolvable->result
-                               :when (not (p/pure-resolvable? resolvable))]
-                           e)
-                         (into {}))]
-      (when-not (empty? cacheable)
-        (cache-put cache env cacheable)))))
+  (fn [env [resolvable] resolvable->result]
+    (when-not (p/pure-resolvable? resolvable)
+      (cache-put cache env resolvable->result))))
 
 (defn- cache-reader
   [cache]

--- a/src/claro/middleware/cache.cljc
+++ b/src/claro/middleware/cache.cljc
@@ -1,0 +1,61 @@
+(ns claro.middleware.cache
+  "A middleware to allow caching of resolution results."
+  (:require [claro.data.protocols :as p]
+            [claro.engine :as engine]
+            [claro.runtime.impl :as impl]
+            [claro.middleware
+             [intercept :refer [wrap-intercept]]
+             [observe :refer [wrap-observe*]]]
+            [potemkin :refer [defprotocol+]]))
+
+;; ## Protocol
+
+(defprotocol+ ResolvableCache
+  "Protocol for cache implementations for resolvables."
+  (cache-get
+    [cache env resolvables]
+    "Lookup cached results for the given resolvables. This should return a map
+     associating resolvables with their value.")
+  (cache-put
+    [cache env resolvable->result]
+    "Put resolved values into the cache."))
+
+;; ## Middleware
+
+(defn- cache-writer
+  [cache]
+  (fn [env batch resolvable->result]
+    (let [cacheable (->> (for [[resolvable result :as e] resolvable->result
+                               :when (not (p/pure-resolvable? resolvable))]
+                           e)
+                         (into {}))]
+      (when-not (empty? cacheable)
+        (cache-put cache env cacheable)))))
+
+(defn- cache-reader
+  [cache]
+  (fn [env batch]
+    (cache-get cache env batch)))
+
+(defn wrap-cache
+  "Wrap the given engine to allow caching and cache lookups of resolvables via
+   the given cache.
+
+   ```clojure
+   (defonce cache
+     (redis-cache ...))
+
+   (defonce engine
+     (-> (engine/engine)
+         (wrap-cache cache)))
+   ```
+
+   Note that `PureResolvable` values will never hit the cache."
+  [engine cache]
+  {:pre [(satisfies? ResolvableCache cache)]}
+  (-> engine
+      (wrap-observe*
+        engine/wrap-pre-transform
+        (cache-writer cache))
+      (wrap-intercept
+        (cache-reader cache))))

--- a/src/claro/middleware/intercept.cljc
+++ b/src/claro/middleware/intercept.cljc
@@ -1,0 +1,50 @@
+(ns claro.middleware.intercept
+  "A middleware to allow partial resolution of batches using a custom resolver."
+  (:require [claro.data.protocols :as p]
+            [claro.engine :as engine]
+            [claro.runtime.impl :as impl]))
+
+;; ## Logic
+
+(defn- resolve-remaining
+  [impl resolver env batch interception-result]
+  (let [intercepted (set (keys interception-result))]
+    (if (empty? intercepted)
+      (resolver env batch)
+      (if-let [remaining (seq (remove intercepted batch))]
+        (impl/chain1
+          impl
+          (resolver env remaining)
+          #(merge interception-result %))
+        interception-result))))
+
+;; ## Middleware
+
+(defn ^{:added "0.2.20"} wrap-intercept
+  "Wrap the given engine to allow resolution of partial batches using different
+   means (e.g. a cache lookup).
+
+   ```clojure
+   (defonce engine
+     (-> (engine/engine)
+         (wrap-intercept
+           (fn [env batch]
+             (lookup-in-cache! env batch)))))
+   ```
+
+   `intercept-fn` has to return a deferred value with a map associating `batch`
+   elements with their result. Everything that was not resolved will be passed
+   to the original resolution logic.
+
+   Note that `PureResolvable` batches will never be passed to the interceptor."
+  [engine intercept-fn]
+  (let [impl (engine/impl engine)]
+    (->> (fn [resolver]
+           (fn [env [resolvable :as batch]]
+             (if-not (p/pure-resolvable? resolvable)
+               (impl/chain1
+                 impl
+                 (intercept-fn env batch)
+                 #(resolve-remaining impl resolver env batch %))
+               (resolver env batch))))
+         (engine/wrap-pre-transform engine))))

--- a/test/claro/middleware/cache_test.clj
+++ b/test/claro/middleware/cache_test.clj
@@ -1,0 +1,84 @@
+(ns claro.middleware.cache-test
+  (:require [clojure.test.check :as tc]
+            [clojure.test.check
+             [clojure-test :refer [defspec]]
+             [generators :as gen]
+             [properties :as prop]]
+            [clojure.test :refer :all]
+            [clojure.set :as set]
+            [claro.test :as test]
+            [claro.data :as data]
+            [claro.engine :as engine]
+            [claro.middleware.cache :refer :all]))
+
+;; ## Resolvable
+
+(defonce counter (atom 0))
+
+(defrecord Counter [id]
+  data/Resolvable
+  (resolve! [_ _]
+    (swap! counter inc)))
+
+(defrecord CounterPure [id]
+  data/PureResolvable
+  data/Resolvable
+  (resolve! [_ _]
+    (swap! counter inc)))
+
+;; ## Cache
+
+(defrecord AtomCache [cache]
+  ResolvableCache
+  (cache-get
+    [_ _ resolvables]
+    (swap! cache vary-meta update :gets (fnil + 0) (count resolvables))
+    (select-keys @cache resolvables))
+  (cache-put
+    [_ _ result]
+    (swap! cache vary-meta update :puts (fnil + 0) (count result))
+    (swap! cache merge result))
+
+  clojure.lang.IDeref
+  (deref [_]
+    @cache))
+
+(defn atom-cache
+  []
+  (->AtomCache (atom {})))
+
+;; ## Helper
+
+(defn- run-with-cache
+  [cache value]
+  (let [run (-> (engine/engine {:check-cost? false})
+                (wrap-cache cache))]
+    @(run value)))
+
+(defn- submap?
+  [v1 v2]
+  (set/subset? (set v1) (set v2)))
+
+;; ## Tests
+
+(defspec t-wrap-cache (test/times 100)
+  (let [cache (atom-cache)]
+    (prop/for-all
+      [values (->> (gen/fmap ->Counter gen/pos-int)
+                   (gen/vector)
+                   (gen/not-empty))]
+      (let [cache-before @cache
+            result       (run-with-cache cache values)
+            cache-after  @cache]
+        (and (not (empty? cache-after))
+             (submap? cache-before cache-after))))))
+
+(defspec t-wrap-cache-ignores-pure-resolvables (test/times 100)
+  (let [cache (atom-cache)]
+    (prop/for-all
+      [values (gen/vector (gen/fmap ->CounterPure gen/pos-int))]
+      (let [cache-before @cache
+            result       (run-with-cache cache values)
+            cache-after  @cache]
+        (and (empty? cache-before)
+             (empty? cache-after))))))

--- a/test/claro/middleware/intercept_test.clj
+++ b/test/claro/middleware/intercept_test.clj
@@ -1,0 +1,57 @@
+(ns claro.middleware.intercept-test
+  (:require [clojure.test.check
+             [clojure-test :refer [defspec]]
+             [generators :as gen]
+             [properties :as prop]]
+            [clojure.test :refer :all]
+            [claro.test :as test]
+            [claro.data :as data]
+            [claro.engine :as engine]
+            [claro.middleware.intercept :refer :all]))
+
+;; ## Resolvables
+
+(defrecord Value [value intercept-value]
+  data/Resolvable
+  (resolve! [_ _]
+    value))
+
+(defrecord PureValue [value intercept-value]
+  data/PureResolvable
+  data/Resolvable
+  (resolve! [_ _]
+    value))
+
+;; ## Helper
+
+(defn run-intercept
+  [value]
+  (let [run! (-> (engine/engine {:check-cost? false})
+                 (wrap-intercept
+                   (fn [_ batch]
+                     (->> (for [{:keys [value intercept-value] :as r} batch
+                                :when intercept-value]
+                            [r intercept-value])
+                          (into {})))))]
+    @(run! value)))
+
+;; ## Tests
+
+(defspec t-wrap-intercept (test/times 100)
+  (prop/for-all
+    [values (->> (gen/tuple gen/int (gen/one-of [gen/int (gen/return nil)]))
+                 (gen/fmap #(apply ->Value %))
+                 (gen/vector))]
+    (= (map
+         (fn [{:keys [intercept-value value]}]
+           (or intercept-value value))
+         values)
+       (run-intercept values))))
+
+(defspec t-wrap-intercept-ignores-pure-resolvables (test/times 100)
+  (prop/for-all
+    [values (->> (gen/tuple gen/int (gen/one-of [gen/int (gen/return nil)]))
+                 (gen/fmap #(apply ->PureValue %))
+                 (gen/vector))]
+    (= (map :value values)
+       (run-intercept values))))


### PR DESCRIPTION
This PR introduces three more middlewares:

- `wrap-observe*` (more low-level observation middleware)
- `wrap-intercept` (intercept resolution and provide results for part of a batch)
- `wrap-cache` (caching middleware)